### PR TITLE
Add customItemsRenderer prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Both options support component customization. - [examples](https://github.com/ke
 | `itemsRenderer`        | `Component` | `items.js`             | `Component to replace the default Items component. `            |
 | `forwardIconRenderer`  | `Component` |                        | `Component to replace the default ForwardIcon component. `      |
 | `treeContainerRenderer`| `Component` | `tree_container.js`    | `Component to replace the default TreeContainer component. `    |
+| `customItemsRenderer ` | `Component` |                        | `Component to replace the default Items && inner Item component.`|
 | `markSelectedItem`     | `boolean`   | `false`                | `Toggle to mark selected item. `                                |
 
 <br/>

--- a/packages/core/src/tree.js
+++ b/packages/core/src/tree.js
@@ -39,6 +39,7 @@ const Tree = props => {
     itemsRenderer: Items = ItemsRenderer,
     forwardIconRenderer,
     treeContainerRenderer: TreeContainer = TreeContainerRenderer,
+    customItemsRenderer,
     selectedItem
   } = props;
 
@@ -94,20 +95,29 @@ const Tree = props => {
         inputIconRenderer={inputIconRenderer}
         clearIconRenderer={clearIconRenderer}
       />
-      <Items styles={styles} getStyles={getStyles} height={itemsHeight}>
-        {leaves &&
-          leaves.length > 0 &&
-          leaves.map(item => (
-            <Item
-              getStyles={getStyles}
-              searchTerm={searchTerm}
-              item={item}
-              onClick={onClick}
-              forwardIconRenderer={forwardIconRenderer}
-              selectedItem={selectedItem}
-            />
-          ))}
-      </Items>
+      {customItemsRenderer ? (
+        React.cloneElement(customItemsRenderer, {
+          ...props,
+          leaves,
+          searchTerm,
+          onClick
+        })
+      ) : (
+        <Items styles={styles} getStyles={getStyles} height={itemsHeight}>
+          {leaves &&
+            leaves.length > 0 &&
+            leaves.map(item => (
+              <Item
+                getStyles={getStyles}
+                searchTerm={searchTerm}
+                item={item}
+                onClick={onClick}
+                forwardIconRenderer={forwardIconRenderer}
+                selectedItem={selectedItem}
+              />
+            ))}
+        </Items>
+      )}
       {leaves && leaves.length === 0 && (
         <NoResults
           height={itemsHeight}

--- a/packages/core/src/tree.js
+++ b/packages/core/src/tree.js
@@ -96,7 +96,13 @@ const Tree = props => {
         clearIconRenderer={clearIconRenderer}
       />
       {customItemsRenderer ? (
-        React.cloneElement(customItemsRenderer, { leaves, searchTerm, onClick })
+        React.cloneElement(customItemsRenderer, {
+          leaves,
+          searchTerm,
+          onClick,
+          selectedItem,
+          forwardIconRenderer
+        })
       ) : (
         <Items styles={styles} getStyles={getStyles} height={itemsHeight}>
           {leaves &&

--- a/packages/core/src/tree.js
+++ b/packages/core/src/tree.js
@@ -96,12 +96,7 @@ const Tree = props => {
         clearIconRenderer={clearIconRenderer}
       />
       {customItemsRenderer ? (
-        React.cloneElement(customItemsRenderer, {
-          ...props,
-          leaves,
-          searchTerm,
-          onClick
-        })
+        React.cloneElement(customItemsRenderer, { leaves, searchTerm, onClick })
       ) : (
         <Items styles={styles} getStyles={getStyles} height={itemsHeight}>
           {leaves &&


### PR DESCRIPTION
We extends from BaseList in hierarchical_select
It's different way to drilling props
In the react-tree it's native div tag.
That's why was added customItemsRenderer
![image](https://user-images.githubusercontent.com/3428923/105726506-d1ee7000-5f32-11eb-8f1c-7f11b3d2641b.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @kenshooui/react-tree@0.0.20-canary.152.423.0
  npm install @kenshooui/material-tree@0.0.3-canary.152.423.0
  # or 
  yarn add @kenshooui/react-tree@0.0.20-canary.152.423.0
  yarn add @kenshooui/material-tree@0.0.3-canary.152.423.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
